### PR TITLE
Add experience page

### DIFF
--- a/src/app/experience/_experience-page.scss
+++ b/src/app/experience/_experience-page.scss
@@ -1,0 +1,6 @@
+@use '@carbon/react/scss/spacing' as *;
+
+.experience-page__r1 {
+  padding-top: $spacing-05;
+  padding-bottom: $spacing-05;
+}

--- a/src/app/experience/page.js
+++ b/src/app/experience/page.js
@@ -1,0 +1,68 @@
+'use client';
+
+import React from 'react';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Accordion,
+  AccordionItem,
+  Grid,
+  Column,
+} from '@carbon/react';
+
+const experiences = [
+  {
+    company: 'Menderes Tekstil',
+    role: 'SAP ABAP Consultant',
+    duration: 'Jan 2019 - Dec 2020',
+    description:
+      'Developed custom SAP modules, optimized manufacturing processes, and integrated ABAP enhancements.',
+  },
+  {
+    company: 'ABC Consulting',
+    role: 'Senior Developer',
+    duration: 'Jan 2021 - Jun 2022',
+    description:
+      'Led a team of developers delivering enterprise web applications using React and Node.js.',
+  },
+  {
+    company: 'XYZ Solutions',
+    role: 'Technical Lead',
+    duration: 'Jul 2022 - Present',
+    description:
+      'Architecting cloud-native solutions and mentoring consultants in agile best practices.',
+  },
+  {
+    company: 'Freelance',
+    role: 'Full Stack Engineer',
+    duration: '2017 - 2018',
+    description:
+      'Implemented end-to-end solutions for small businesses, focusing on e‑commerce and automation.',
+  },
+];
+
+export default function ExperiencePage() {
+  return (
+    <Grid className="experience-page">
+      <Column lg={16} md={8} sm={4} className="experience-page__r1">
+        <Breadcrumb noTrailingSlash aria-label="breadcrumb">
+          <BreadcrumbItem href="/">Home</BreadcrumbItem>
+          <BreadcrumbItem href="/experience">Experience</BreadcrumbItem>
+        </Breadcrumb>
+        <h1 style={{ marginTop: '1rem', marginBottom: '1rem' }}>
+          Professional Experience
+        </h1>
+        <Accordion align="start">
+          {experiences.map(({ company, role, duration, description }) => (
+            <AccordionItem
+              key={`${company}-${role}`}
+              title={`${company} – ${role} (${duration})`}
+            >
+              <p>{description}</p>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </Column>
+    </Grid>
+  );
+}

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -8,6 +8,7 @@
 @use '@/app/repos/repo-page';
 @use '@/app/publications/publication-page';
 @use '@/app/projects/projects-page';
+@use '@/app/experience/experience-page';
 
 /// Remove overrides once Carbon bugs are fixed upstream.
 /// Need grid option to not add page gutters at large viewports, to also use when nesting grids

--- a/src/components/TutorialHeader/TutorialHeader.js
+++ b/src/components/TutorialHeader/TutorialHeader.js
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import {
   Header,
@@ -13,10 +13,10 @@ import {
   SideNav,
   SideNavItems,
   HeaderSideNavItems,
-} from "@carbon/react";
-import { Switcher, Notification, UserAvatar } from "@carbon/icons-react";
+} from '@carbon/react';
+import { Switcher, Notification, UserAvatar } from '@carbon/icons-react';
 
-import Link from "next/link";
+import Link from 'next/link';
 
 const TutorialHeader = () => (
   <HeaderContainer
@@ -41,6 +41,9 @@ const TutorialHeader = () => (
           <Link href="/projects" passHref legacyBehavior>
             <HeaderMenuItem>Projects</HeaderMenuItem>
           </Link>
+          <Link href="/experience" passHref legacyBehavior>
+            <HeaderMenuItem>Experience</HeaderMenuItem>
+          </Link>
         </HeaderNavigation>
         <SideNav
           aria-label="Side navigation"
@@ -55,8 +58,10 @@ const TutorialHeader = () => (
               <Link href="/projects" passHref legacyBehavior>
                 <HeaderMenuItem>Projects</HeaderMenuItem>
               </Link>
+              <Link href="/experience" passHref legacyBehavior>
+                <HeaderMenuItem>Experience</HeaderMenuItem>
+              </Link>
             </HeaderSideNavItems>
-            
           </SideNavItems>
         </SideNav>
         <HeaderGlobalBar>


### PR DESCRIPTION
## Summary
- add Professional Experience page using Carbon Accordion
- hook up new page in app styling
- link Experience page in header navigation

## Testing
- `yarn format` *(fails: package doesn't seem present in lockfile)*
- `yarn lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6862ef0d2400832e90e61f8056e46a72