### PR TITLE
Add skills page

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -8,6 +8,7 @@
 @use '@/app/repos/repo-page';
 @use '@/app/publications/publication-page';
 @use '@/app/projects/projects-page';
+@use '@/app/skills/skills-page';
 
 /// Remove overrides once Carbon bugs are fixed upstream.
 /// Need grid option to not add page gutters at large viewports, to also use when nesting grids

--- a/src/app/skills/_skills-page.scss
+++ b/src/app/skills/_skills-page.scss
@@ -1,0 +1,17 @@
+@use '@carbon/react/scss/spacing' as *;
+
+.skills-page__r1 {
+  padding-top: $spacing-05;
+  padding-bottom: $spacing-05;
+}
+
+.skills-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-03;
+  margin-top: $spacing-03;
+}
+
+.skills-tags .cds--tag:hover {
+  background-color: var(--cds-layer-hover);
+}

--- a/src/app/skills/page.js
+++ b/src/app/skills/page.js
@@ -1,0 +1,68 @@
+'use client';
+
+import React from 'react';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Accordion,
+  AccordionItem,
+  Grid,
+  Column,
+  Tag,
+} from '@carbon/react';
+
+const skillsData = [
+  {
+    category: 'Programming Languages',
+    skills: ['JavaScript', 'TypeScript', 'Python', 'C++', 'SQL'],
+  },
+  {
+    category: 'SAP Modules',
+    skills: ['SAP HANA', 'SAP Fiori', 'SAP BW', 'SAP ABAP', 'SAP PI/PO'],
+  },
+  {
+    category: 'Soft Skills',
+    skills: [
+      'Leadership',
+      'Communication',
+      'Agile Methodologies',
+      'Problem Solving',
+      'Mentoring',
+    ],
+  },
+  {
+    category: 'Cloud & Tools',
+    skills: ['AWS', 'Docker', 'Kubernetes', 'Terraform', 'Jenkins'],
+  },
+  {
+    category: 'Other Technologies',
+    skills: ['GraphQL', 'Redux', 'Jest', 'Sass', 'Git'],
+  },
+];
+
+export default function SkillsPage() {
+  return (
+    <Grid className="skills-page">
+      <Column lg={16} md={8} sm={4} className="skills-page__r1">
+        <Breadcrumb noTrailingSlash aria-label="breadcrumb">
+          <BreadcrumbItem href="/">Home</BreadcrumbItem>
+          <BreadcrumbItem href="/skills">Skills &amp; Tools</BreadcrumbItem>
+        </Breadcrumb>
+        <h1 style={{ marginTop: '1rem', marginBottom: '1rem' }}>
+          Skills &amp; Tools
+        </h1>
+        <Accordion align="start">
+          {skillsData.map(({ category, skills }) => (
+            <AccordionItem key={category} title={category}>
+              <div className="skills-tags">
+                {skills.map((skill) => (
+                  <Tag key={skill}>{skill}</Tag>
+                ))}
+              </div>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </Column>
+    </Grid>
+  );
+}

--- a/src/components/TutorialHeader/TutorialHeader.js
+++ b/src/components/TutorialHeader/TutorialHeader.js
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import {
   Header,
@@ -13,10 +13,10 @@ import {
   SideNav,
   SideNavItems,
   HeaderSideNavItems,
-} from "@carbon/react";
-import { Switcher, Notification, UserAvatar } from "@carbon/icons-react";
+} from '@carbon/react';
+import { Switcher, Notification, UserAvatar } from '@carbon/icons-react';
 
-import Link from "next/link";
+import Link from 'next/link';
 
 const TutorialHeader = () => (
   <HeaderContainer
@@ -41,6 +41,9 @@ const TutorialHeader = () => (
           <Link href="/projects" passHref legacyBehavior>
             <HeaderMenuItem>Projects</HeaderMenuItem>
           </Link>
+          <Link href="/skills" passHref legacyBehavior>
+            <HeaderMenuItem>Skills</HeaderMenuItem>
+          </Link>
         </HeaderNavigation>
         <SideNav
           aria-label="Side navigation"
@@ -55,8 +58,10 @@ const TutorialHeader = () => (
               <Link href="/projects" passHref legacyBehavior>
                 <HeaderMenuItem>Projects</HeaderMenuItem>
               </Link>
+              <Link href="/skills" passHref legacyBehavior>
+                <HeaderMenuItem>Skills</HeaderMenuItem>
+              </Link>
             </HeaderSideNavItems>
-            
           </SideNavItems>
         </SideNav>
         <HeaderGlobalBar>


### PR DESCRIPTION
## Summary
- add Skills & Tools page with Carbon components
- style skills page and import styles
- link Skills page in TutorialHeader navigation

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn format:diff` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6862efdc3570832eb58600d076f6098b