### PR TITLE
Add skills page

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -8,6 +8,7 @@
 @use '@/app/repos/repo-page';
 @use '@/app/publications/publication-page';
 @use '@/app/projects/projects-page';
+@use '@/app/skills/skills-page';
 
 /// Remove overrides once Carbon bugs are fixed upstream.
 /// Need grid option to not add page gutters at large viewports, to also use when nesting grids

--- a/src/app/skills/_skills-page.scss
+++ b/src/app/skills/_skills-page.scss
@@ -1,0 +1,28 @@
+@use '@carbon/react/scss/spacing' as *;
+
+.skills-page__r1 {
+  padding-top: $spacing-05;
+  padding-bottom: $spacing-05;
+}
+
+.skill-tile {
+  height: 100%;
+  padding: $spacing-05;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  &:hover {
+    background-color: var(--cds-layer-hover);
+  }
+}
+
+.skill-header {
+  margin-bottom: $spacing-03;
+}
+
+.skill-progress {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-03;
+}

--- a/src/app/skills/page.js
+++ b/src/app/skills/page.js
@@ -1,0 +1,119 @@
+'use client';
+
+import React from 'react';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Grid,
+  Column,
+  Tile,
+  ProgressBar,
+} from '@carbon/react';
+import {
+  Code,
+  DataBase,
+  Group,
+  CloudApp,
+  Apps,
+} from '@carbon/icons-react';
+
+const skillsData = [
+  {
+    category: 'Programming Languages',
+    description: 'Core languages for modern development',
+    icon: Code,
+    skills: [
+      { name: 'JavaScript', level: 90 },
+      { name: 'TypeScript', level: 80 },
+      { name: 'Python', level: 85 },
+      { name: 'C++', level: 70 },
+      { name: 'SQL', level: 75 },
+    ],
+  },
+  {
+    category: 'SAP Modules',
+    description: 'Enterprise resource planning expertise',
+    icon: DataBase,
+    skills: [
+      { name: 'SAP HANA', level: 80 },
+      { name: 'SAP Fiori', level: 70 },
+      { name: 'SAP BW', level: 65 },
+      { name: 'SAP ABAP', level: 75 },
+    ],
+  },
+  {
+    category: 'Soft Skills',
+    description: 'Collaboration and leadership capabilities',
+    icon: Group,
+    skills: [
+      { name: 'Leadership', level: 90 },
+      { name: 'Communication', level: 85 },
+      { name: 'Agile Methodologies', level: 80 },
+      { name: 'Problem Solving', level: 90 },
+    ],
+  },
+  {
+    category: 'Cloud & Tools',
+    description: 'Cloud platforms and DevOps toolchain',
+    icon: CloudApp,
+    skills: [
+      { name: 'AWS', level: 75 },
+      { name: 'Docker', level: 80 },
+      { name: 'Kubernetes', level: 70 },
+      { name: 'Terraform', level: 65 },
+      { name: 'Jenkins', level: 70 },
+    ],
+  },
+  {
+    category: 'Other Technologies',
+    description: 'Additional frameworks and libraries',
+    icon: Apps,
+    skills: [
+      { name: 'GraphQL', level: 70 },
+      { name: 'Redux', level: 75 },
+      { name: 'Jest', level: 80 },
+      { name: 'Sass', level: 90 },
+      { name: 'Git', level: 85 },
+    ],
+  },
+];
+
+export default function SkillsPage() {
+  return (
+    <Grid className="skills-page">
+      <Column lg={16} md={8} sm={4} className="skills-page__r1">
+        <Breadcrumb noTrailingSlash aria-label="breadcrumb">
+          <BreadcrumbItem href="/">Home</BreadcrumbItem>
+          <BreadcrumbItem href="/skills">Skills &amp; Tools</BreadcrumbItem>
+        </Breadcrumb>
+        <h1 style={{ marginTop: '1rem', marginBottom: '1rem' }}>
+          Skills &amp; Tools
+        </h1>
+      </Column>
+      {skillsData.map(({ category, description, icon: Icon, skills }) => (
+        <Column key={category} lg={5} md={4} sm={4}>
+          <Tile className="skill-tile">
+            <div className="skill-header">
+              {Icon && (
+                <Icon width={32} height={32} aria-hidden="true" />
+              )}
+              <h3 style={{ marginBottom: '0.25rem' }}>{category}</h3>
+              <p className="skill-description">{description}</p>
+            </div>
+            <div className="skill-progress">
+              {skills.map(({ name, level }) => (
+                <ProgressBar
+                  key={name}
+                  label={name}
+                  value={level}
+                  max={100}
+                  size="small"
+                />
+              ))}
+            </div>
+          </Tile>
+        </Column>
+      ))}
+    </Grid>
+  );
+}

--- a/src/components/TutorialHeader/TutorialHeader.js
+++ b/src/components/TutorialHeader/TutorialHeader.js
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import {
   Header,
@@ -13,10 +13,10 @@ import {
   SideNav,
   SideNavItems,
   HeaderSideNavItems,
-} from "@carbon/react";
-import { Switcher, Notification, UserAvatar } from "@carbon/icons-react";
+} from '@carbon/react';
+import { Switcher, Notification, UserAvatar } from '@carbon/icons-react';
 
-import Link from "next/link";
+import Link from 'next/link';
 
 const TutorialHeader = () => (
   <HeaderContainer
@@ -41,6 +41,9 @@ const TutorialHeader = () => (
           <Link href="/projects" passHref legacyBehavior>
             <HeaderMenuItem>Projects</HeaderMenuItem>
           </Link>
+          <Link href="/skills" passHref legacyBehavior>
+            <HeaderMenuItem>Skills</HeaderMenuItem>
+          </Link>
         </HeaderNavigation>
         <SideNav
           aria-label="Side navigation"
@@ -55,8 +58,10 @@ const TutorialHeader = () => (
               <Link href="/projects" passHref legacyBehavior>
                 <HeaderMenuItem>Projects</HeaderMenuItem>
               </Link>
+              <Link href="/skills" passHref legacyBehavior>
+                <HeaderMenuItem>Skills</HeaderMenuItem>
+              </Link>
             </HeaderSideNavItems>
-            
           </SideNavItems>
         </SideNav>
         <HeaderGlobalBar>


### PR DESCRIPTION
## Summary
- add Skills & Tools page with Carbon tile layout and progress bars
- style skills page tiles
- link Skills page in TutorialHeader navigation

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn format:diff` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6862efdc3570832eb58600d076f6098b