### PR TITLE
feat: add circular hero portrait

### DIFF
--- a/public/profile.svg
+++ b/public/profile.svg
@@ -1,0 +1,18 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title>Portrait placeholder for Fatih Şengül</title>
+  <desc>Stylized avatar illustration with gradient background</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f62fe" />
+      <stop offset="100%" stop-color="#8a3ffc" />
+    </linearGradient>
+    <linearGradient id="shirt" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#161616" />
+      <stop offset="100%" stop-color="#393939" />
+    </linearGradient>
+  </defs>
+  <circle cx="320" cy="320" r="300" fill="url(#bg)" />
+  <circle cx="320" cy="240" r="120" fill="#f4f4f4" />
+  <path d="M160 500c0-94 72-146 160-146s160 52 160 146" fill="url(#shirt)" />
+  <path d="M216 500c14-54 56-88 104-88s90 34 104 88" fill="#6f6f6f" opacity="0.7" />
+</svg>

--- a/src/app/home/_home-page.scss
+++ b/src/app/home/_home-page.scss
@@ -108,15 +108,31 @@
   align-items: center;
   justify-content: center;
   background-color: $layer-accent-01;
-  border-radius: $spacing-03;
+  border-radius: $spacing-05;
   overflow: hidden;
 }
 
-.home-page__pictogram {
-  width: 100%;
-  height: 100%;
-  opacity: 0.3;
-  fill: $icon-primary;
+.home-page__portrait-wrapper {
+  position: relative;
+  width: 72%;
+  padding-top: 72%;
+  border-radius: 50%;
+  overflow: hidden;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+
+  @include breakpoint-down(md) {
+    width: 80%;
+    padding-top: 80%;
+  }
+
+  @include breakpoint-down(sm) {
+    width: 88%;
+    padding-top: 88%;
+  }
+}
+
+.home-page__portrait {
+  object-fit: cover;
 }
 
 .home-page__stats-overlay {

--- a/src/app/home/page.js
+++ b/src/app/home/page.js
@@ -21,8 +21,8 @@ import {
   Code,
   DataProcessing,
   DeliverInsights,
-  MachineLearning_05 as MachineLearning,
 } from '@carbon/pictograms-react';
+import Image from 'next/image';
 
 export default function LandingPage() {
   return (
@@ -75,7 +75,16 @@ export default function LandingPage() {
             <div className="home-page__hero-illustration">
               <AspectRatio ratio="1x1">
                 <div className="home-page__hero-illustration-content">
-                  <MachineLearning className="home-page__pictogram" />
+                  <div className="home-page__portrait-wrapper">
+                    <Image
+                      src="/profile.svg"
+                      alt="Portrait of Fatih Şengül"
+                      fill
+                      priority
+                      sizes="(max-width: 1056px) 80vw, 640px"
+                      className="home-page__portrait"
+                    />
+                  </div>
                   <Tile className="home-page__stats-overlay">
                     <div className="home-page__stats-item">
                       <span className="home-page__stats-number">6+</span>


### PR DESCRIPTION
## Summary
- replace the home hero pictogram with a portrait rendered via next/image
- add circular portrait styling and responsive sizing without changing the grid structure
- include a local portrait illustration asset for the homepage hero

## Testing
- Not run (project lint prompts for configuration and no existing setup)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c0d7774a0832e9581e2197c2061f0)